### PR TITLE
fix: ensure page view tracker and skiplink are wrapped in i18n provider

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -103,10 +103,6 @@ export default function LocaleLayout(props: LocaleLayoutProps): ReactNode {
 
 				<ColorSchemeScript />
 
-				<AnalyticsScript baseUrl={env.NEXT_PUBLIC_MATOMO_BASE_URL} id={env.NEXT_PUBLIC_MATOMO_ID} />
-
-				<SkipLink targetId={id}>{t("skip-to-main-content")}</SkipLink>
-
 				{/**
 				 * @see https://react-spectrum.adobe.com/react-aria/ssr.html#optimizing-bundle-size
 				 *
@@ -131,6 +127,13 @@ export default function LocaleLayout(props: LocaleLayoutProps): ReactNode {
 						"TranslatorsPage",
 					])}
 				>
+					<AnalyticsScript
+						baseUrl={env.NEXT_PUBLIC_MATOMO_BASE_URL}
+						id={env.NEXT_PUBLIC_MATOMO_ID}
+					/>
+
+					<SkipLink targetId={id}>{t("skip-to-main-content")}</SkipLink>
+
 					<AppLayout>
 						<AppHeader />
 						{children}


### PR DESCRIPTION
this ensures that the page view tracker for matomo is wrapped in the client-side i18n provider. this does not fix an actual runtime issue, but avoids annoying build-time warnings in the logs.